### PR TITLE
Fix: properly order multiple chars inserted with the same `prev`

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function HyperString (db, opts) {
         if (row.value.prev) {
           var prev = self.stringDag[row.value.prev]
           if (!prev) throw new Error('woah, this should never happen!')
-          prev.links.push(row.key)
+          prev.links.unshift(row.key)
         }
 
         // set as a root if no hyperlog links

--- a/test/basic.js
+++ b/test/basic.js
@@ -113,3 +113,18 @@ test('deletions', function (t) {
     })
   })
 })
+
+test('insert with same prev twice', function (t) {
+  t.plan(1)
+  var str = hstring(memdb())
+
+  str.insert(null, 'H', function (err, op1) {
+    str.insert(op1.pos, 'y', function (err, op2) {
+      str.insert(op1.pos, 'e', function (err, op3) {
+        str.text(function (err, text) {
+          t.equal(text, 'Hey')
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
See the failing test and the fix.

The newest char inserted should be processed first, hence the unshift.
